### PR TITLE
Add static inline prefix to several functions in include/linux/of.h

### DIFF
--- a/include/linux/of.h
+++ b/include/linux/of.h
@@ -1078,14 +1078,14 @@ static inline int of_changeset_create_device_node(struct of_changeset *ocs,
 	return -EINVAL;
 }
 
-int of_changeset_add_property_copy(struct of_changeset *ocs,
+static inline int of_changeset_add_property_copy(struct of_changeset *ocs,
 	struct device_node *np, const char *name,
 	const void *value, int length)
 {
 	return -EINVAL;
 }
 
-int of_changeset_add_property_string(struct of_changeset *ocs,
+static inline int of_changeset_add_property_string(struct of_changeset *ocs,
 	struct device_node *np, const char *name, const char *str)
 {
 	return -EINVAL;
@@ -1106,19 +1106,19 @@ static inline __printf(4, 5) struct device_node *
 	return ERR_PTR(-EINVAL);
 }
 
-int of_changeset_add_property_string_list(struct of_changeset *ocs,
+static inline int of_changeset_add_property_string_list(struct of_changeset *ocs,
 	struct device_node *np, const char *name, const char **strs, int count)
 {
 	return -EINVAL;
 }
 
-int of_changeset_add_property_u32(struct of_changeset *ocs,
+static inline int of_changeset_add_property_u32(struct of_changeset *ocs,
 	struct device_node *np, const char *name, u32 val)
 {
 	return -EINVAL;
 }
 
-int of_changeset_add_property_bool(struct of_changeset *ocs,
+static inline int of_changeset_add_property_bool(struct of_changeset *ocs,
 	struct device_node *np, const char *name)
 {
 	return -EINVAL;


### PR DESCRIPTION
I encountered this issue when compiling using Robert Nelson's bb-kernel scripts:
https://groups.google.com/forum/#!topic/beagleboard/YfzVUmptfIE

Adding a `static inline` prefix to several functions in `include/linux/of.h` resolved this issue.
